### PR TITLE
Update the README to reflect the actual name

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Then require `fluidvids` in your file:
 
 ```javascript
 // Note that it is called as a function
-var fluidvids = require('fluidvids')();
+var fluidvids = require('fluidvids.js')();
 ```
 
 ## Manual installation


### PR DESCRIPTION
After installing through NPM, I needed to require _fluidvids.js_ since that is the name in the _package.json_.
